### PR TITLE
include <stdint.h>

### DIFF
--- a/arm64.h
+++ b/arm64.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 uint32_t generate_movk(uint8_t x, uint16_t val, uint16_t lsl);
 uint32_t generate_br(uint8_t x);


### PR DESCRIPTION
this is needed to build the tool outside of theos’s build system (but theos builds the tool fine without it, so i’ll leave it up to you whether you think this is a necessary merge or not)